### PR TITLE
Add Nix expressions for shell and container

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,62 @@
+{
+  "nodes": {
+    "nixng": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1641337254,
+        "narHash": "sha256-h4zTaiqFOlWNGVhBdQc3AqYqcOQ1GjCKn7wY6KbZkuk=",
+        "owner": "MagicRB",
+        "repo": "NixNG",
+        "rev": "5126892070a00a183cdaeae0d313e99d87a3b399",
+        "type": "github"
+      },
+      "original": {
+        "owner": "MagicRB",
+        "repo": "NixNG",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1641244400,
+        "narHash": "sha256-8i4oasWEz/2y9U+F1XU15jfwSbd5YOEBh2tyBBm/W8E=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c6019d8efb5530dcf7ce98086b8e091be5ff900a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-21.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1641870998,
+        "narHash": "sha256-6HkxR2WZsm37VoQS7jgp6Omd71iw6t1kP8bDbaqCDuI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "386234e2a61e1e8acf94dfa3a3d3ca19a6776efb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-21.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixng": "nixng",
+        "nixpkgs": "nixpkgs_2"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,65 @@
+{
+  inputs =
+    { nixpkgs.url = "github:NixOS/nixpkgs?ref=nixos-21.11";
+      nixng.url = "github:MagicRB/NixNG";
+    };
+
+  outputs =
+    { self, nixpkgs, nixng }:
+    let
+      supportedSystems = [ "x86_64-linux" ];
+      forAllSystems' = nixpkgs.lib.genAttrs;
+      forAllSystems = forAllSystems' supportedSystems;
+      pkgsForSystems = system: import nixpkgs { inherit system; };
+      nglib = nixng.nglib nixpkgs.lib;
+    in
+      { dockerImages = forAllSystems (system:
+          {
+            db = nglib.makeSystem
+              { inherit nixpkgs;
+                system = "x86_64-linux";
+                name = "shop-db";
+                config =
+                  ({ pkgs, ... }:
+                    { dumb-init =
+                        { enable = true;
+                          type.services = { };
+                        };
+                      services.postgresql =
+                        { enable = true;
+                          package = pkgs.postgresql_12;
+
+                          ensureDatabases =
+                            [ "shop"
+                            ];
+
+                          ensureUsers =
+                            [ { name = "shop";
+                                ensurePermissions =
+                                  { "DATABASE \"shop\"" = "ALL PRIVILEGES"; };
+                              }
+                            ];
+
+                          authentication =
+                            ''
+                              host all all 0.0.0.0/0 trust
+                            '';
+
+                          enableTCPIP = true;
+                        };
+                    });
+              };
+          }
+        );
+
+        devShell = forAllSystems (system:
+          let pkgs = pkgsForSystems system;
+          in
+            pkgs.mkShell {
+              nativeBuildInputs = with pkgs;
+                [ postgresql_12
+                ];
+            }
+        );
+      };
+}


### PR DESCRIPTION
Signed-off-by: main <magic_rb@redalder.org>

To build the container use:

```
nix --experimental-features "nix-command flakes" build .#dockerImages.x86_64-linux.db.config.system.build.ociImage.stream
```

Then load the built image:

```
./result | docker load
```

Finally run the container:

```
docker run -p 5432:5432 -v $PWD/pgsql-data:/var/lib/postgresql -d shop-db
```